### PR TITLE
Render read-only, column enums as their values

### DIFF
--- a/flask_superadmin/base.py
+++ b/flask_superadmin/base.py
@@ -122,7 +122,7 @@ class BaseView(metaclass=AdminViewMeta):
             )
 
     def create_blueprint(self, admin):
-        """ Create Flask blueprint. """
+        """Create Flask blueprint."""
 
         # Store admin instance
         self.admin = admin
@@ -236,7 +236,7 @@ class AdminIndexView(BaseView):
 
 
 class MenuItem(object):
-    """ Simple menu tree hierarchy. """
+    """Simple menu tree hierarchy."""
 
     def __init__(self, name, view=None):
         self.name = name
@@ -288,7 +288,7 @@ class MenuItem(object):
 
 
 class Admin(object):
-    """ Collection of the views. Also manages menu structure. """
+    """Collection of the views. Also manages menu structure."""
 
     app = None
 
@@ -466,5 +466,5 @@ class Admin(object):
             self._add_view_to_menu(view)
 
     def menu(self):
-        """ Return menu hierarchy. """
+        """Return menu hierarchy."""
         return self._menu

--- a/flask_superadmin/model/base.py
+++ b/flask_superadmin/model/base.py
@@ -1,3 +1,4 @@
+from enum import Enum
 import math
 import re
 
@@ -181,6 +182,8 @@ class BaseModelAdmin(BaseView):
                 # Check if the value is a reference field to a doc/model
                 # registered in the admin. If so, link to it.
                 reference = self.get_reference(val)
+                if isinstance(val, Enum):
+                    val = val.value
                 val = {
                     "label": prettify(field),
                     "value": val,

--- a/flask_superadmin/model/base.py
+++ b/flask_superadmin/model/base.py
@@ -149,6 +149,9 @@ class BaseModelAdmin(BaseView):
                 if callable(value):
                     value = value()
 
+            if isinstance(value, Enum):
+                value = value.value
+
             if not value:
                 break
 


### PR DESCRIPTION
Looks like `readonly_fields` are not processed by `convert`

https://github.com/closeio/Flask-SuperAdmin/blob/8c35bf333ea1e1d90a215c2c46d3323fe96e27ca/flask_superadmin/model/backends/mongoengine/orm.py#L244-L246

I went for the very "local" (AKA hacky) approach of just checking if the value is an `Enum` in those two scenarios and replacing it with the corresponding `.value`. Think this way the patch is contained (won't affect non-readonly fields that are not enums).

Alternatively, we could drop the `not in readonly_fields` check (was added [here](https://github.com/syrusakbary/Flask-SuperAdmin/pull/68)), but that would require additional modification to the template macros ([such as here](https://github.com/closeio/Flask-SuperAdmin/blob/667a3be864d46ed6e5aa592229c0fc86a8c6f897/flask_superadmin/templates/superadmin/_macros.html#L172)) probably more than that because read-only fields are rendered differently from normal ones and [wouldn't cover columns either](https://github.com/closeio/Flask-SuperAdmin/blob/4e0e346765387bf1c24400fb57f739677e4c1012/flask_superadmin/templates/superadmin/model/list.html#L105).
